### PR TITLE
Switch Javadoc version while switching Java

### DIFF
--- a/javasetter/javasetter.go
+++ b/javasetter/javasetter.go
@@ -104,14 +104,16 @@ func (j JavaSetter) setJavaMac(version JavaVersion) (Result, error) {
 }
 
 func (j JavaSetter) setJavaUbuntu(version JavaVersion) (Result, error) {
-	javaPath, javaCPath, javaHome := func() (string, string, string) {
+	javaPath, javaCPath, javadocPath, javaHome := func() (string, string, string, string) {
 		switch version {
 		case JavaVersion8:
-			return "/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java", "/usr/lib/jvm/java-8-openjdk-amd64/bin/javac", "/usr/lib/jvm/java-8-openjdk-amd64"
+			mainDir := "/usr/lib/jvm/java-8-openjdk-amd64"
+			return mainDir+"/jre/bin/java", mainDir+"/bin/javac", mainDir+"/bin/javadoc", mainDir
 		case JavaVersion11:
-			return "/usr/lib/jvm/java-11-openjdk-amd64/bin/java", "/usr/lib/jvm/java-11-openjdk-amd64/bin/javac", "/usr/lib/jvm/java-11-openjdk-amd64"
+			mainDir := "/usr/lib/jvm/java-11-openjdk-amd64"
+			return mainDir+"/bin/java", mainDir+"/bin/javac", mainDir+"/bin/javadoc", mainDir
 		default:
-			return "", "", ""
+			return "", "", "", ""
 		}
 	}()
 
@@ -153,5 +155,24 @@ func (j JavaSetter) setJavaUbuntu(version JavaVersion) (Result, error) {
 	if _, err := cmd.RunAndReturnExitCode(); err != nil {
 		return Result{}, err
 	}
+
+	//
+	// update-alternatives javadoc
+	cmd := j.cmdFactory.Create(
+		"sudo",
+		[]string{
+			"update-alternatives",
+			"--set",
+			"javadoc",
+			javadocPath,
+		},
+		nil,
+	)
+
+	j.logger.Printf("$ %s", cmd.PrintableCommandArgs())
+	if _, err := cmd.RunAndReturnExitCode(); err != nil {
+		return Result{}, err
+	}
+
 	return Result{JavaHome: javaHome}, nil
 }

--- a/javasetter/javasetter.go
+++ b/javasetter/javasetter.go
@@ -158,7 +158,7 @@ func (j JavaSetter) setJavaUbuntu(version JavaVersion) (Result, error) {
 
 	//
 	// update-alternatives javadoc
-	cmd := j.cmdFactory.Create(
+	cmd = j.cmdFactory.Create(
 		"sudo",
 		[]string{
 			"update-alternatives",


### PR DESCRIPTION
### Checklist

- [x] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires PATCH [version update](https://semver.org/)

### Context

Projects that generate javadocs should be able to switch the Javadoc tool version while switching Java versions

### Changes

On unix machines additional `update-alternatives` command is triggered in order to set a proper path to Javadoc tool. On MacOS the change is not needed since Jenv already takes care of it.

