### PR TITLE
Add JDK21 to selectable options

### DIFF
--- a/javasetter/javasetter.go
+++ b/javasetter/javasetter.go
@@ -17,6 +17,7 @@ const (
 	JavaVersion8  = JavaVersion("8")
 	JavaVersion11 = JavaVersion("11")
 	JavaVersion17 = JavaVersion("17")
+	JavaVersion21 = JavaVersion("21")
 )
 
 // Platform ...
@@ -92,6 +93,8 @@ func (j JavaSetter) setJavaMac(version JavaVersion) (Result, error) {
 		versions = []string{"11", "11.0"}
 	case JavaVersion17:
 		versions = []string{"17", "17.0"}
+	case JavaVersion21:
+		versions = []string{"21", "21.0"}
 	}
 
 	//
@@ -124,6 +127,9 @@ func (j JavaSetter) setJavaUbuntu(version JavaVersion) (Result, error) {
 		javaPath = filepath.Join(javaHome, "bin/java")
 	case JavaVersion17:
 		javaHome = "/usr/lib/jvm/java-17-openjdk-amd64"
+		javaPath = filepath.Join(javaHome, "bin/java")
+	case JavaVersion21:
+		javaHome = "/usr/lib/jvm/java-21-openjdk-amd64"
 		javaPath = filepath.Join(javaHome, "bin/java")
 	}
 

--- a/step.yml
+++ b/step.yml
@@ -37,6 +37,7 @@ inputs:
       You can check [in system reports](https://stacks.bitrise.io) which Java versions are installed on each Bitrise stack.
     is_required: true
     value_options:
+    - "21"
     - "17"
     - "11"
     - "8"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

JDK 21 is now preinstalled on the Ubuntu 22 stack (and soon be installed on macOS stacks too)

### Changes

Add new option for selecting JDK 21

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
